### PR TITLE
fix(location): support AddressCoordinates GeoServiceVerified error

### DIFF
--- a/src/client/api/location/mod.rs
+++ b/src/client/api/location/mod.rs
@@ -47,7 +47,6 @@ pub struct GeoCoordinates {
 
 #[allow(missing_docs)]
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
 #[serde(rename_all = "snake_case")]
 pub enum GeoServiceVerified {
     Verified,


### PR DESCRIPTION
## Description

I received the following error when trying out this API:

```bash
thread 'main' (1191873) panicked at src/main.rs:57:10:
Getting locations should not fail: RequestError(reqwest::Error { kind: Decode, source: Error("unknown variant `address_coordinates`, expected `verified` or `unverified`", line: 1, column: 348) })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is my PR to attempt to address the issue.