### PR TITLE
fix: optional is_jobsite LocationData field

### DIFF
--- a/src/client/api/location/mod.rs
+++ b/src/client/api/location/mod.rs
@@ -73,7 +73,7 @@ pub struct LocationData {
     pub geo_service_verified: GeoServiceVerified,
 
     /// Whether the location is a job site.
-    pub is_jobsite: bool,
+    pub is_jobsite: Option<bool>,
 
     /// Whether the location is being shared from a different account.
     pub is_owner: bool,


### PR DESCRIPTION
## Description

I was receiving this error when performing a location lookup:

```bash
Getting locations should not fail: RequestError(reqwest::Error { kind: Decode, source: Error("missing field `is_jobsite`", line: 1, column: 550) })
```